### PR TITLE
Bugfix/multi connection socket map

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,7 +233,9 @@ workerPromise.then(function (worker) {
             return this._promise;
         }
     };
-
+    
+    worker.apiGateway =  mockGateway;
+    
     wss.on('connection', function connection(ws, req) {
 
         console.log("ws: New Websocket Connection with Remote IP:", req.socket.remoteAddress ," Remote Port: ", req.socket.remotePort ,  "ConnectionId:",req.socket.connectionId);
@@ -257,11 +259,6 @@ workerPromise.then(function (worker) {
         */
        //const ip = req.headers['x-forwarded-for'].split(/\s*,\s*/)[0];
 
-        //Overrides with our dev equivalent
-        ws.apiGateway = mockGateway;
-        worker.apiGateway =  mockGateway;
-
-        
         var mockContext = {},
         mockCallback = function(){};
 
@@ -291,9 +288,6 @@ workerPromise.then(function (worker) {
             var mockDefaultContext = {},
                 mockDefaultCallback = function(error, result){},
                 callbackCalled = false;
-
-            
-            worker.apiGateway = ws.apiGateway;
 
             var defaultPromise = functionModule.default( {
                     requestContext: {
@@ -374,7 +368,6 @@ workerPromise.then(function (worker) {
             var mockDefaultContext = {},
             mockDefaultCallback = function(){};
             
-            worker.apiGateway = ws.apiGateway;
 
             functionModule.default( {
                     requestContext: {

--- a/index.js
+++ b/index.js
@@ -1,184 +1,167 @@
 //global.Promise = require("bluebird");
-const http = require("http");
-const https = require("https");
-const WebSocket = require("ws");
-const url = require("url");
+const http = require('http');
+const https = require('https');
+const WebSocket = require('ws');
+const url = require('url');
 const URL = url.URL;
 const URLSearchParams = url.URLSearchParams;
-const fs = require("fs");
+const fs = require('fs');
+
 
 /**
  * The timeoutPromise helper allows you to wrap any promise to fulfill within a timeout.
- *
+ * 
  * @param {Promise} promise A promise instance
  * @param {BigInteger} timeoutInMilliseconds The time limit in milliseconds to fulfill or reject the promise.
  * @returns {Promise} A pending Promise
  */
-function PromiseTimeout(promise, timeoutInMilliseconds) {
-  return Promise.race([
-    promise,
-    new Promise(function (resolve, reject) {
-      setTimeout(function () {
-        reject(new Error("timeout"));
-      }, timeoutInMilliseconds);
-    }),
-  ]);
-}
+function PromiseTimeout(promise, timeoutInMilliseconds){
+    return Promise.race([
+        promise, 
+        new Promise(function(resolve, reject){
+            setTimeout(function() {
+                reject(new Error("timeout"));
+            }, timeoutInMilliseconds);
+        })
+    ]);
+};
+
 
 /*
     Input from https://blog.zackad.dev/en/2017/08/19/create-websocket-with-nodejs.html
 */
 //See https://www.npmjs.com/package/commander
-const { program } = require("commander");
+const { program } = require('commander');
 
-program
-  .option("-f, --function <function>", "The serveless function to run")
-  .option("-p, --port <port>", "The websocket port to use", 7272)
-  .option("-s, --stage <stage>", "The stage to use", "staging")
-  .option(
-    "-c, --cert <sslCertificatePath>",
-    "Path to the ssl certificate file to use",
-    null,
-  )
-  .option("-k, --key <sslKeyPath>", "Path to the ssl key file to use", null)
-  .option(
-    "-gt, --gatewayTimeout <timeout>",
-    "A timeout for message delivery getting something back",
-    null,
-  );
+program.option('-f, --function <function>', 'The serveless function to run')
+        .option('-p, --port <port>', 'The websocket port to use', 7272)
+        .option('-s, --stage <stage>', 'The stage to use', "staging")
+        .option('-c, --cert <sslCertificatePath>', 'Path to the ssl certificate file to use', null)
+        .option('-k, --key <sslKeyPath>', 'Path to the ssl key file to use', null)
+        .option('-gt, --gatewayTimeout <timeout>', 'A timeout for message delivery getting something back', null);
 
 program.parse(process.argv);
 var uuid = require("mod/core/uuid");
 var functionPath = program.function,
-  port = program.port,
-  sslCertificatePath = program.cert,
-  sslKeyPath = program.key,
-  gatewayTimeout =
-    program.gatewayTimeout /* || 29000, */ /* ms - the hard-coded timeout of the AWS APIGateway */,
-  functionModuleId,
-  functionModuledDirName,
-  functionModule,
-  OperationCoordinatorPromise,
-  privateKey,
-  certificate,
-  credentials;
+    port = program.port,
+    sslCertificatePath = program.cert,
+    sslKeyPath = program.key,
+    gatewayTimeout = program.gatewayTimeout, /* || 29000, *//* ms - the hard-coded timeout of the AWS APIGateway */
+    functionModuleId,
+    functionModuledDirName,
+    functionModule,
+    OperationCoordinatorPromise,
+    privateKey,
+    certificate,
+    credentials;
 
-// read ssl certificate
-if (sslCertificatePath && sslKeyPath) {
-  privateKey = fs.readFileSync(sslKeyPath, "utf8");
-  certificate = fs.readFileSync(sslCertificatePath, "utf8");
-  credentials = { key: privateKey, cert: certificate };
-}
+    // read ssl certificate
+    if(sslCertificatePath && sslKeyPath) {
+        privateKey = fs.readFileSync(sslKeyPath, 'utf8');
+        certificate = fs.readFileSync(sslCertificatePath, 'utf8');
+        credentials = { key: privateKey, cert: certificate };        
+    }
 
-functionModuledDirName = functionPath.substring(
-  0,
-  functionPath.lastIndexOf("/"),
-);
+functionModuledDirName = functionPath.substring(0,functionPath.lastIndexOf("/"));
 
-if (functionPath.endsWith(".js")) {
-  functionModuleId = functionPath.substring(0, functionPath.length - 3);
-  // functionModuleId = functionPath.substring(functionPath.lastIndexOf("/")+1,functionPath.length-3);
+if(functionPath.endsWith(".js")) {
+    functionModuleId = functionPath.substring(0,functionPath.length-3);
+    // functionModuleId = functionPath.substring(functionPath.lastIndexOf("/")+1,functionPath.length-3);
 }
 
 functionModule = require(functionModuleId);
 
 /*
-    As we move to transition from mr's require(async) to node's require (sync) we need to do some tweaking here
+    As we move to transition from mr's require(async) to node's require (sync) we need to do some tweaking here 
 */
 var workerPromise;
-if (
-  functionModule &&
-  functionModule.worker &&
-  typeof functionModule.worker.then !== "function"
-) {
-  workerPromise = Promise.resolve(functionModule);
+if(functionModule && functionModule.worker && typeof functionModule.worker.then !== "function") {
+    workerPromise = Promise.resolve(functionModule);
 } else {
-  workerPromise = functionModule.worker;
+    workerPromise = functionModule.worker;
 }
 
 workerPromise.then(function (worker) {
-  function authorizeAsync(request, socket, head) {
-    const ip = socket.remoteAddress ? socket.remoteAddress : "127.0.0.1";
-    const headers = request.headers;
-    const url = new URL(
-      request.url,
-      headers.origin ? headers.origin : `http://${headers.host}`,
-    );
-    const userAgent = headers["user-agent"];
 
-    if (!socket.connectionId) {
-      socket.connectionId = uuid.generate();
-    }
+    function authorizeAsync(request, socket, head) {
+        const ip = socket.remoteAddress ? socket.remoteAddress : "127.0.0.1";
+        const headers = request.headers;
+        const url = new URL(request.url, headers.origin ? headers.origin : `http://${headers.host}`);
+        const userAgent = headers["user-agent"];
 
-    return new Promise(function (resolve, reject) {
-      var callbackCalled = false;
-      var mockContext = {
-          callbackWaitsForEmptyEventLoop: true,
-        },
-        callback = function (authResponseError, authResponseData) {
-          var statements;
+        if(!socket.connectionId) {
+            socket.connectionId = uuid.generate();
+        }
 
-          callbackCalled = true;
-          if (authResponseError) {
-            reject(authResponseError);
-          } else if (
-            (statements = authResponseData?.policyDocument?.Statement)
-          ) {
-            var hasDeny = false,
-              hasAllow = false,
-              countI = statements.length,
-              i = 0;
-
-            for (; i < countI; i++) {
-              if (statements[i].Effect !== "Allow") {
-                console.log("main authorize authResponse Deny:", authResponse);
-                if (timer) console.log(timer.runtimeMsStr());
-                hasDeny = true;
-                break;
-              } else {
-                hasAllow = true;
-              }
-            }
-
-            if (hasDeny) {
-              reject(new Error("Unauthorized"));
-            } else if (hasAllow) {
-              socket.principalId = authResponseData.principalId;
-              resolve(authResponseData);
-            }
-          } else {
-            reject(new Error(JSON.stringify(authResponseData)));
-          }
-        },
-        event = {
-          type: "REQUEST",
-          requestContext: {
-            connectionId: socket.connectionId,
-            stage: program.stage,
-            identity: {
-              sourceIp: ip,
-              userAgent: userAgent,
+        return new Promise(function(resolve, reject) {
+            var callbackCalled = false;
+            var mockContext = {
+                callbackWaitsForEmptyEventLoop: true
             },
-          },
-          headers: headers,
-          body: "",
-        },
-        queryStringParameters,
-        multiValueQueryStringParameters;
+            callback = function(authResponseError, authResponseData) {
+                var statements;
 
-      // console.log("request:",request);
-      // console.log("socket:",socket);
+                callbackCalled = true;
+                if(authResponseError) {
+                    reject(authResponseError);
+                } else if((statements = authResponseData?.policyDocument?.Statement)) {
 
-      const searchParams = url.searchParams;
+                    var hasDeny = false,
+                        hasAllow = false,
+                        countI = statements.length,
+                        i = 0;
+                
+                    for(; ( i < countI); i++ ) {
+                        if(statements[i].Effect !== "Allow") {
+                            console.log("main authorize authResponse Deny:",authResponse);
+                            if(timer) console.log(timer.runtimeMsStr());
+                            hasDeny = true;
+                            break;
+                        } else {
+                            hasAllow = true;
+                        }
+                    }
 
-      //Iterate the search parameters.
-      for (let p of searchParams) {
-        //console.log("searchParams: ", p);
+                    if(hasDeny) {
+                        reject(new Error("Unauthorized"));
+                    }
+                    else if(hasAllow) {
+                        socket.principalId = authResponseData.principalId;
+                        resolve(authResponseData);
+                    }
 
-        (queryStringParameters || (queryStringParameters = {}))[p[0]] = p[1];
-        (multiValueQueryStringParameters ||
-          (multiValueQueryStringParameters = {}))[p[0]] = [p[1]];
-        /*
+                } else {
+                    reject(new Error(JSON.stringify(authResponseData)));
+                }
+            },
+            event = {
+                type: 'REQUEST',
+                requestContext: {
+                        connectionId: socket.connectionId,
+                        stage: program.stage,
+                        identity: {
+                            sourceIp: ip,
+                            userAgent: userAgent
+                        }
+                    },
+                    "headers": headers,
+                    "body":""
+                },
+                queryStringParameters,
+                multiValueQueryStringParameters;
+    
+            // console.log("request:",request);
+            // console.log("socket:",socket);
+
+            const searchParams = url.searchParams;
+
+            //Iterate the search parameters.
+            for (let p of searchParams) {
+                //console.log("searchParams: ", p);
+
+                (queryStringParameters || (queryStringParameters = {}))[p[0]] = p[1];
+                (multiValueQueryStringParameters || (multiValueQueryStringParameters = {}))[p[0]] = [p[1]];
+                /*
 
                     queryStringParameters: {
                     identity: 'ewogICJjcml0ZXJpYSI6IHsKICAgICJwcm90b3R5cGUiOiAibW9udGFnZS9jb3JlL2NyaXRlcmlhIiwKICAgICJ2YWx1ZXMiOiB7CiAgICAgICJleHByZXNzaW9uIjogIm9yaWdpbklkID09ICQub3JpZ2luSWQiLAogICAgICAicGFyYW1ldGVycyI6IHsKICAgICAgICAib3JpZ2luSWQiOiAiMTg3Y2ZhOWEtYzMwMy00NzM3LWE3NzAtMTdkNDZlNzUyNGE0IgogICAgICB9CiAgICB9CiAgfSwKICAiZGF0YXF1ZXJ5IjogewogICAgInByb3RvdHlwZSI6ICJtb250YWdlL2RhdGEvbW9kZWwvZGF0YS1xdWVyeSIsCiAgICAidmFsdWVzIjogewogICAgICAiY3JpdGVyaWEiOiB7IkAiOiAiY3JpdGVyaWEifSwKICAgICAgInR5cGVNb2R1bGUiOiB7CiAgICAgICAgIiUiOiAibW9udGFnZS9kYXRhL21vZGVsL2RhdGEtaWRlbnRpdHkubWpzb24iCiAgICAgIH0KICAgIH0KICB9LAogICJyb290IjogewogICAgInByb3RvdHlwZSI6ICJtb250YWdlL2RhdGEvbW9kZWwvZGF0YS1pZGVudGl0eSIsCiAgICAidmFsdWVzIjogewogICAgICAicXVlcnkiOiB7IkAiOiAiZGF0YXF1ZXJ5In0KICAgIH0KICB9Cn0='
@@ -189,243 +172,243 @@ workerPromise.then(function (worker) {
                     ]
                     },
                 */
-      }
-
-      if (queryStringParameters) {
-        event.queryStringParameters = queryStringParameters;
-        event.multiValueQueryStringParameters = multiValueQueryStringParameters;
-      }
-
-      //Needs to inject stage property for phront service to use the right info
-      var authorizePromise = functionModule.authorize(
-        event,
-        mockContext,
-        callback,
-      );
-
-      if (authorizePromise) {
-        authorizePromise.then(
-          (resolvedValue) => {
-            if (!callbackCalled) {
-              callback(null, resolvedValue);
             }
-          },
-          (error) => {
-            if (!callbackCalled) {
-              callback(error);
+
+            if(queryStringParameters) {
+                event.queryStringParameters = queryStringParameters;
+                event.multiValueQueryStringParameters = multiValueQueryStringParameters;
             }
-          },
-        );
-      }
-    });
-    //return new Promise((resolve) => setTimeout(resolve.bind(null, 'Hello world'), 500));
-  }
+  
 
-  const server = credentials
-    ? https.createServer(credentials)
-    : http.createServer();
+            //Needs to inject stage property for phront service to use the right info
+            var authorizePromise = functionModule.authorize( event,
+                mockContext,
+                callback
+            );
 
-  const wss = new WebSocket.Server({ noServer: true });
-  console.log("Starting a websocket server!");
+            if(authorizePromise) {
+                authorizePromise.then((resolvedValue) => {
+                    if(!callbackCalled) {
+                        callback(null, resolvedValue);
+                    }
+                    
+                }, (error) => {
+                    if(!callbackCalled) {
+                        callback(error);
+                    }
+                })
 
-  const websocketTable = {};
+            }
+        });
+        //return new Promise((resolve) => setTimeout(resolve.bind(null, 'Hello world'), 500));
+    }
 
-  const mockGateway = {
-    postToConnection: function (params) {
-      this._promise = new Promise(function (resolve, reject) {
-        /* params looks like:
+    const server = credentials ?  https.createServer(credentials) : http.createServer();
+
+    const wss = new WebSocket.Server({ noServer: true });
+    console.log("Starting a websocket server!");
+
+    const websocketTable = {};
+
+    const mockGateway =  {
+        postToConnection: function(params) {
+            this._promise = new Promise(function(resolve,reject) { 
+                /* params looks like:
                     {
                         ConnectionId: event.requestContext.connectionId,
                         Data: self._serializer.serializeObject(readOperationCompleted)
                     }
                 */
-        var connectionId = params.ConnectionId;
-        var response_ws = websocketTable[connectionId];
-        var serializedHandledOperation = params.Data;
-        console.log("ws: params", params);
-        console.log(
-          "ws: respond ws remote port",
-          response_ws._socket.remotePort,
-        );
-        // TODO: What should we do if the websocket is closed right before this?
-        response_ws.send(serializedHandledOperation);
-        resolve(true);
-      });
-      return this;
-    },
-    promise: function () {
-      return this._promise;
-    },
-  };
+            var connectionId = params.ConnectionId;
+            var response_ws = websocketTable[connectionId];
+            var serializedHandledOperation = params.Data;
+            console.log("Sending response on Websocket Connection with Remote IP:", response_ws._socket.remoteAddress ," Remote Port: ", response_ws._socket.remotePort ,  "ConnectionId:",response_ws._socket.connectionId);
+            response_ws.send(serializedHandledOperation);
+            resolve(true);
 
-  wss.on("connection", function connection(ws, req) {
-    console.log("ws: init ws remote port", ws._socket.remotePort);
-    const ip = req ? req.socket.remoteAddress : "127.0.0.1";
-    const headers = req.headers;
-    const userAgent = headers["user-agent"];
-    websocketTable[req.socket.connectionId] = ws;
+            });
+            return this;
+        },
+        promise: function() {
+            return this._promise;
+        }
+    };
 
-    ws.on("close", function close() {
-      console.log("Closing ws");
-      delete websocketTable[req.socket.connectionId];
-    });
+    wss.on('connection', function connection(ws, req) {
 
-    ws.on("error", function ws_error() {
-      console.log("Error in  ws");
-      delete websocketTable[req.socket.connectionId];
+        console.log("ws: New Websocket Connection with Remote IP:", req.socket.remoteAddress ," Remote Port: ", req.socket.remotePort ,  "ConnectionId:",req.socket.connectionId);
+        const ip = req ? req.socket.remoteAddress: "127.0.0.1";
+        const headers = req.headers;
+        const userAgent = headers["user-agent"];
+        websocketTable[req.socket.connectionId] = ws;
+
+        ws.on('close', function close() {
+            console.log("Closing ws");
+            delete websocketTable[req.socket.connectionId];
+        });
+
+        ws.on('error', function ws_error() {
+            console.log("Error in ws");
+            delete websocketTable[req.socket.connectionId];
+         });
+
+        /*
+            When the server runs behind a proxy like NGINX, the de-facto standard is to use the X-Forwarded-For header.
+        */
+       //const ip = req.headers['x-forwarded-for'].split(/\s*,\s*/)[0];
+
+
+        
+
+        console.log("ws: mockGateway",mockGateway);
+
+        //Overrides with our dev equivalent
+        ws.apiGateway = mockGateway;
+        worker.apiGateway =  mockGateway;
+
+        
+        var mockContext = {},
+        mockCallback = function(){};
+
+        //Needs to inject stage property for phront service to use the right info
+        functionModule.connect( {
+                requestContext: {
+                    connectionId: req.socket.connectionId,
+                    stage: program.stage,
+                    identity: {
+                        sourceIp: ip,
+                        userAgent: userAgent
+                    },
+                    authorizer: {
+                        principalId: req.socket.principalId
+                    }
+                },
+                "headers": headers,
+                "body":""
+            },
+            mockContext,
+            mockCallback
+        );    
+
+
+    
+        ws.on('message', function incoming(message) {
+            var mockDefaultContext = {},
+                mockDefaultCallback = function(error, result){},
+                callbackCalled = false;
+
+            
+            worker.apiGateway = ws.apiGateway;
+
+            var defaultPromise = functionModule.default( {
+                    requestContext: {
+                        connectionId: req.socket.connectionId,
+                        stage: program.stage,
+                        identity: {
+                            sourceIp: ip,
+                            userAgent: userAgent
+                        },
+                        authorizer: {
+                            principalId: req.socket.principalId
+                        }
+                    },
+                    "headers": headers,
+                    "body":message
+                },
+                mockDefaultContext,
+                mockDefaultCallback
+            );    
+          
+            if(defaultPromise) {
+                defaultPromise.then((resolvedValue) => {
+                    if(!callbackCalled) {
+                        mockDefaultCallback(null, resolvedValue);
+                    }
+                    
+                }, (error) => {
+                    if(!callbackCalled) {
+                        mockDefaultCallback(error);
+                    }
+                })
+            }
+
+                //console.log('received: %s', message);
+        });
+     
+        //ws.send('something');
     });
 
     /*
-            When the server runs behind a proxy like NGINX, the de-facto standard is to use the X-Forwarded-For header.
-        */
-    //const ip = req.headers['x-forwarded-for'].split(/\s*,\s*/)[0];
-
-    console.log("ws: mockGateway", mockGateway);
-
-    //Overrides with our dev equivalent
-    ws.apiGateway = mockGateway;
-    worker.apiGateway = mockGateway;
-
-    var mockContext = {},
-      mockCallback = function () {};
-
-    //Needs to inject stage property for phront service to use the right info
-    functionModule.connect(
-      {
-        requestContext: {
-          connectionId: req.socket.connectionId,
-          stage: program.stage,
-          identity: {
-            sourceIp: ip,
-            userAgent: userAgent,
-          },
-          authorizer: {
-            principalId: req.socket.principalId,
-          },
-        },
-        headers: headers,
-        body: "",
-      },
-      mockContext,
-      mockCallback,
-    );
-
-    ws.on("message", function incoming(message) {
-      var mockDefaultContext = {},
-        mockDefaultCallback = function (error, result) {},
-        callbackCalled = false;
-
-      worker.apiGateway = ws.apiGateway;
-
-      var defaultPromise = functionModule.default(
-        {
-          requestContext: {
-            connectionId: req.socket.connectionId,
-            stage: program.stage,
-            identity: {
-              sourceIp: ip,
-              userAgent: userAgent,
-            },
-            authorizer: {
-              principalId: req.socket.principalId,
-            },
-          },
-          headers: headers,
-          body: message,
-        },
-        mockDefaultContext,
-        mockDefaultCallback,
-      );
-
-      if (defaultPromise) {
-        defaultPromise.then(
-          (resolvedValue) => {
-            if (!callbackCalled) {
-              mockDefaultCallback(null, resolvedValue);
-            }
-          },
-          (error) => {
-            if (!callbackCalled) {
-              mockDefaultCallback(error);
-            }
-          },
-        );
-      }
-
-      //console.log('received: %s', message);
-    });
-
-    //ws.send('something');
-  });
-
-  /*
         inspired by https://github.com/websockets/ws/issues/377
     */
 
-  server.on("upgrade", async (request, socket, head) => {
-    let data;
-
-    try {
-      if (gatewayTimeout) {
-        data = await PromiseTimeout(
-          authorizeAsync(request, socket, head),
-          gatewayTimeout,
-        );
-      } else {
-        data = await authorizeAsync(request, socket, head);
-      }
-    } catch (error) {
-      console.log("on upgrade error: ", error);
-      socket.write(`HTTP/1.1 500 ${http.STATUS_CODES[500]}\r\n\r\n`);
-      socket.destroy();
-      return;
-    }
-
-    wss.handleUpgrade(request, socket, head, (ws) => {
-      wss.emit("connection", ws, request, data);
-    });
-  });
-
-  server.on("request", (request, response) => {
-    // handle requests
-
-    let data = [];
-    request
-      .on("data", (d) => {
-        data.push(d);
-      })
-      .on("end", () => {
-        data = Buffer.concat(data).toString();
-
-        var mockDefaultContext = {},
-          mockDefaultCallback = function () {};
-
-        worker.apiGateway = ws.apiGateway;
-
-        functionModule.default(
-          {
-            requestContext: {
-              connectionId: req.socket.connectionId,
-              stage: program.stage,
-              identity: {
-                sourceIp: ip,
-                userAgent: userAgent,
-              },
-              authorizer: {
-                principalId: req.socket.principalId,
-              },
-            },
-            headers: headers,
-            body: message,
-          },
-          mockDefaultContext,
-          mockDefaultCallback,
-        );
-
-        response.statusCode = 201;
-        response.end();
+    server.on('upgrade', async (request, socket, head) => {
+        let data;
+      
+        try {
+            if(gatewayTimeout) {
+                data = await PromiseTimeout(authorizeAsync(request, socket, head), gatewayTimeout);
+            } else {
+                data = await authorizeAsync(request, socket, head);
+            }
+        } catch (error) {
+            console.log("on upgrade error: ", error);
+            socket.write(`HTTP/1.1 500 ${http.STATUS_CODES[500]}\r\n\r\n`);
+            socket.destroy();
+            return;
+        }
+      
+        wss.handleUpgrade(request, socket, head, (ws) => {
+            wss.emit('connection', ws, request, data);
+        });
       });
-  });
+      
 
-  server.listen(port);
+    server.on("request", (request, response) => {
+        // handle requests
+
+        let data = []
+        request
+          .on("data", d => {
+            data.push(d)
+          })
+          .on("end", () => {
+            data = Buffer.concat(data).toString();
+
+
+            var mockDefaultContext = {},
+            mockDefaultCallback = function(){};
+            
+            worker.apiGateway = ws.apiGateway;
+
+            functionModule.default( {
+                    requestContext: {
+                        connectionId: req.socket.connectionId,
+                        stage: program.stage,
+                        identity: {
+                            sourceIp: ip,
+                            userAgent: userAgent
+                        },
+                        authorizer: {
+                            principalId: req.socket.principalId
+                        }
+                    },
+                    "headers": headers,
+                    "body":message
+                },
+                mockDefaultContext,
+                mockDefaultCallback
+            );    
+
+
+
+            response.statusCode = 201;
+            response.end();
+          })
+      
+    });
+      
+    server.listen(port);
+
 });
+

--- a/index.js
+++ b/index.js
@@ -1,167 +1,184 @@
 //global.Promise = require("bluebird");
-const http = require('http');
-const https = require('https');
-const WebSocket = require('ws');
-const url = require('url');
+const http = require("http");
+const https = require("https");
+const WebSocket = require("ws");
+const url = require("url");
 const URL = url.URL;
 const URLSearchParams = url.URLSearchParams;
-const fs = require('fs');
-
+const fs = require("fs");
 
 /**
  * The timeoutPromise helper allows you to wrap any promise to fulfill within a timeout.
- * 
+ *
  * @param {Promise} promise A promise instance
  * @param {BigInteger} timeoutInMilliseconds The time limit in milliseconds to fulfill or reject the promise.
  * @returns {Promise} A pending Promise
  */
-function PromiseTimeout(promise, timeoutInMilliseconds){
-    return Promise.race([
-        promise, 
-        new Promise(function(resolve, reject){
-            setTimeout(function() {
-                reject(new Error("timeout"));
-            }, timeoutInMilliseconds);
-        })
-    ]);
-};
-
+function PromiseTimeout(promise, timeoutInMilliseconds) {
+  return Promise.race([
+    promise,
+    new Promise(function (resolve, reject) {
+      setTimeout(function () {
+        reject(new Error("timeout"));
+      }, timeoutInMilliseconds);
+    }),
+  ]);
+}
 
 /*
     Input from https://blog.zackad.dev/en/2017/08/19/create-websocket-with-nodejs.html
 */
 //See https://www.npmjs.com/package/commander
-const { program } = require('commander');
+const { program } = require("commander");
 
-program.option('-f, --function <function>', 'The serveless function to run')
-        .option('-p, --port <port>', 'The websocket port to use', 7272)
-        .option('-s, --stage <stage>', 'The stage to use', "staging")
-        .option('-c, --cert <sslCertificatePath>', 'Path to the ssl certificate file to use', null)
-        .option('-k, --key <sslKeyPath>', 'Path to the ssl key file to use', null)
-        .option('-gt, --gatewayTimeout <timeout>', 'A timeout for message delivery getting something back', null);
+program
+  .option("-f, --function <function>", "The serveless function to run")
+  .option("-p, --port <port>", "The websocket port to use", 7272)
+  .option("-s, --stage <stage>", "The stage to use", "staging")
+  .option(
+    "-c, --cert <sslCertificatePath>",
+    "Path to the ssl certificate file to use",
+    null,
+  )
+  .option("-k, --key <sslKeyPath>", "Path to the ssl key file to use", null)
+  .option(
+    "-gt, --gatewayTimeout <timeout>",
+    "A timeout for message delivery getting something back",
+    null,
+  );
 
 program.parse(process.argv);
 var uuid = require("mod/core/uuid");
 var functionPath = program.function,
-    port = program.port,
-    sslCertificatePath = program.cert,
-    sslKeyPath = program.key,
-    gatewayTimeout = program.gatewayTimeout, /* || 29000, *//* ms - the hard-coded timeout of the AWS APIGateway */
-    functionModuleId,
-    functionModuledDirName,
-    functionModule,
-    OperationCoordinatorPromise,
-    privateKey,
-    certificate,
-    credentials;
+  port = program.port,
+  sslCertificatePath = program.cert,
+  sslKeyPath = program.key,
+  gatewayTimeout =
+    program.gatewayTimeout /* || 29000, */ /* ms - the hard-coded timeout of the AWS APIGateway */,
+  functionModuleId,
+  functionModuledDirName,
+  functionModule,
+  OperationCoordinatorPromise,
+  privateKey,
+  certificate,
+  credentials;
 
-    // read ssl certificate
-    if(sslCertificatePath && sslKeyPath) {
-        privateKey = fs.readFileSync(sslKeyPath, 'utf8');
-        certificate = fs.readFileSync(sslCertificatePath, 'utf8');
-        credentials = { key: privateKey, cert: certificate };        
-    }
+// read ssl certificate
+if (sslCertificatePath && sslKeyPath) {
+  privateKey = fs.readFileSync(sslKeyPath, "utf8");
+  certificate = fs.readFileSync(sslCertificatePath, "utf8");
+  credentials = { key: privateKey, cert: certificate };
+}
 
-functionModuledDirName = functionPath.substring(0,functionPath.lastIndexOf("/"));
+functionModuledDirName = functionPath.substring(
+  0,
+  functionPath.lastIndexOf("/"),
+);
 
-if(functionPath.endsWith(".js")) {
-    functionModuleId = functionPath.substring(0,functionPath.length-3);
-    // functionModuleId = functionPath.substring(functionPath.lastIndexOf("/")+1,functionPath.length-3);
+if (functionPath.endsWith(".js")) {
+  functionModuleId = functionPath.substring(0, functionPath.length - 3);
+  // functionModuleId = functionPath.substring(functionPath.lastIndexOf("/")+1,functionPath.length-3);
 }
 
 functionModule = require(functionModuleId);
 
 /*
-    As we move to transition from mr's require(async) to node's require (sync) we need to do some tweaking here 
+    As we move to transition from mr's require(async) to node's require (sync) we need to do some tweaking here
 */
 var workerPromise;
-if(functionModule && functionModule.worker && typeof functionModule.worker.then !== "function") {
-    workerPromise = Promise.resolve(functionModule);
+if (
+  functionModule &&
+  functionModule.worker &&
+  typeof functionModule.worker.then !== "function"
+) {
+  workerPromise = Promise.resolve(functionModule);
 } else {
-    workerPromise = functionModule.worker;
+  workerPromise = functionModule.worker;
 }
 
 workerPromise.then(function (worker) {
+  function authorizeAsync(request, socket, head) {
+    const ip = socket.remoteAddress ? socket.remoteAddress : "127.0.0.1";
+    const headers = request.headers;
+    const url = new URL(
+      request.url,
+      headers.origin ? headers.origin : `http://${headers.host}`,
+    );
+    const userAgent = headers["user-agent"];
 
-    function authorizeAsync(request, socket, head) {
-        const ip = socket.remoteAddress ? socket.remoteAddress : "127.0.0.1";
-        const headers = request.headers;
-        const url = new URL(request.url, headers.origin ? headers.origin : `http://${headers.host}`);
-        const userAgent = headers["user-agent"];
+    if (!socket.connectionId) {
+      socket.connectionId = uuid.generate();
+    }
 
-        if(!socket.connectionId) {
-            socket.connectionId = uuid.generate();
-        }
+    return new Promise(function (resolve, reject) {
+      var callbackCalled = false;
+      var mockContext = {
+          callbackWaitsForEmptyEventLoop: true,
+        },
+        callback = function (authResponseError, authResponseData) {
+          var statements;
 
-        return new Promise(function(resolve, reject) {
-            var callbackCalled = false;
-            var mockContext = {
-                callbackWaitsForEmptyEventLoop: true
+          callbackCalled = true;
+          if (authResponseError) {
+            reject(authResponseError);
+          } else if (
+            (statements = authResponseData?.policyDocument?.Statement)
+          ) {
+            var hasDeny = false,
+              hasAllow = false,
+              countI = statements.length,
+              i = 0;
+
+            for (; i < countI; i++) {
+              if (statements[i].Effect !== "Allow") {
+                console.log("main authorize authResponse Deny:", authResponse);
+                if (timer) console.log(timer.runtimeMsStr());
+                hasDeny = true;
+                break;
+              } else {
+                hasAllow = true;
+              }
+            }
+
+            if (hasDeny) {
+              reject(new Error("Unauthorized"));
+            } else if (hasAllow) {
+              socket.principalId = authResponseData.principalId;
+              resolve(authResponseData);
+            }
+          } else {
+            reject(new Error(JSON.stringify(authResponseData)));
+          }
+        },
+        event = {
+          type: "REQUEST",
+          requestContext: {
+            connectionId: socket.connectionId,
+            stage: program.stage,
+            identity: {
+              sourceIp: ip,
+              userAgent: userAgent,
             },
-            callback = function(authResponseError, authResponseData) {
-                var statements;
+          },
+          headers: headers,
+          body: "",
+        },
+        queryStringParameters,
+        multiValueQueryStringParameters;
 
-                callbackCalled = true;
-                if(authResponseError) {
-                    reject(authResponseError);
-                } else if((statements = authResponseData?.policyDocument?.Statement)) {
+      // console.log("request:",request);
+      // console.log("socket:",socket);
 
-                    var hasDeny = false,
-                        hasAllow = false,
-                        countI = statements.length,
-                        i = 0;
-                
-                    for(; ( i < countI); i++ ) {
-                        if(statements[i].Effect !== "Allow") {
-                            console.log("main authorize authResponse Deny:",authResponse);
-                            if(timer) console.log(timer.runtimeMsStr());
-                            hasDeny = true;
-                            break;
-                        } else {
-                            hasAllow = true;
-                        }
-                    }
+      const searchParams = url.searchParams;
 
-                    if(hasDeny) {
-                        reject(new Error("Unauthorized"));
-                    }
-                    else if(hasAllow) {
-                        socket.principalId = authResponseData.principalId;
-                        resolve(authResponseData);
-                    }
+      //Iterate the search parameters.
+      for (let p of searchParams) {
+        //console.log("searchParams: ", p);
 
-                } else {
-                    reject(new Error(JSON.stringify(authResponseData)));
-                }
-            },
-            event = {
-                type: 'REQUEST',
-                requestContext: {
-                        connectionId: socket.connectionId,
-                        stage: program.stage,
-                        identity: {
-                            sourceIp: ip,
-                            userAgent: userAgent
-                        }
-                    },
-                    "headers": headers,
-                    "body":""
-                },
-                queryStringParameters,
-                multiValueQueryStringParameters;
-    
-            // console.log("request:",request);
-            // console.log("socket:",socket);
-
-            const searchParams = url.searchParams;
-
-            //Iterate the search parameters.
-            for (let p of searchParams) {
-                //console.log("searchParams: ", p);
-
-                (queryStringParameters || (queryStringParameters = {}))[p[0]] = p[1];
-                (multiValueQueryStringParameters || (multiValueQueryStringParameters = {}))[p[0]] = [p[1]];
-                /*
+        (queryStringParameters || (queryStringParameters = {}))[p[0]] = p[1];
+        (multiValueQueryStringParameters ||
+          (multiValueQueryStringParameters = {}))[p[0]] = [p[1]];
+        /*
 
                     queryStringParameters: {
                     identity: 'ewogICJjcml0ZXJpYSI6IHsKICAgICJwcm90b3R5cGUiOiAibW9udGFnZS9jb3JlL2NyaXRlcmlhIiwKICAgICJ2YWx1ZXMiOiB7CiAgICAgICJleHByZXNzaW9uIjogIm9yaWdpbklkID09ICQub3JpZ2luSWQiLAogICAgICAicGFyYW1ldGVycyI6IHsKICAgICAgICAib3JpZ2luSWQiOiAiMTg3Y2ZhOWEtYzMwMy00NzM3LWE3NzAtMTdkNDZlNzUyNGE0IgogICAgICB9CiAgICB9CiAgfSwKICAiZGF0YXF1ZXJ5IjogewogICAgInByb3RvdHlwZSI6ICJtb250YWdlL2RhdGEvbW9kZWwvZGF0YS1xdWVyeSIsCiAgICAidmFsdWVzIjogewogICAgICAiY3JpdGVyaWEiOiB7IkAiOiAiY3JpdGVyaWEifSwKICAgICAgInR5cGVNb2R1bGUiOiB7CiAgICAgICAgIiUiOiAibW9udGFnZS9kYXRhL21vZGVsL2RhdGEtaWRlbnRpdHkubWpzb24iCiAgICAgIH0KICAgIH0KICB9LAogICJyb290IjogewogICAgInByb3RvdHlwZSI6ICJtb250YWdlL2RhdGEvbW9kZWwvZGF0YS1pZGVudGl0eSIsCiAgICAidmFsdWVzIjogewogICAgICAicXVlcnkiOiB7IkAiOiAiZGF0YXF1ZXJ5In0KICAgIH0KICB9Cn0='
@@ -172,219 +189,243 @@ workerPromise.then(function (worker) {
                     ]
                     },
                 */
+      }
+
+      if (queryStringParameters) {
+        event.queryStringParameters = queryStringParameters;
+        event.multiValueQueryStringParameters = multiValueQueryStringParameters;
+      }
+
+      //Needs to inject stage property for phront service to use the right info
+      var authorizePromise = functionModule.authorize(
+        event,
+        mockContext,
+        callback,
+      );
+
+      if (authorizePromise) {
+        authorizePromise.then(
+          (resolvedValue) => {
+            if (!callbackCalled) {
+              callback(null, resolvedValue);
             }
-
-            if(queryStringParameters) {
-                event.queryStringParameters = queryStringParameters;
-                event.multiValueQueryStringParameters = multiValueQueryStringParameters;
+          },
+          (error) => {
+            if (!callbackCalled) {
+              callback(error);
             }
-  
+          },
+        );
+      }
+    });
+    //return new Promise((resolve) => setTimeout(resolve.bind(null, 'Hello world'), 500));
+  }
 
-            //Needs to inject stage property for phront service to use the right info
-            var authorizePromise = functionModule.authorize( event,
-                mockContext,
-                callback
-            );
+  const server = credentials
+    ? https.createServer(credentials)
+    : http.createServer();
 
-            if(authorizePromise) {
-                authorizePromise.then((resolvedValue) => {
-                    if(!callbackCalled) {
-                        callback(null, resolvedValue);
+  const wss = new WebSocket.Server({ noServer: true });
+  console.log("Starting a websocket server!");
+
+  const websocketTable = {};
+
+  const mockGateway = {
+    postToConnection: function (params) {
+      this._promise = new Promise(function (resolve, reject) {
+        /* params looks like:
+                    {
+                        ConnectionId: event.requestContext.connectionId,
+                        Data: self._serializer.serializeObject(readOperationCompleted)
                     }
-                    
-                }, (error) => {
-                    if(!callbackCalled) {
-                        callback(error);
-                    }
-                })
+                */
+        var connectionId = params.ConnectionId;
+        var response_ws = websocketTable[connectionId];
+        var serializedHandledOperation = params.Data;
+        console.log("ws: params", params);
+        console.log(
+          "ws: respond ws remote port",
+          response_ws._socket.remotePort,
+        );
+        // TODO: What should we do if the websocket is closed right before this?
+        response_ws.send(serializedHandledOperation);
+        resolve(true);
+      });
+      return this;
+    },
+    promise: function () {
+      return this._promise;
+    },
+  };
 
-            }
-        });
-        //return new Promise((resolve) => setTimeout(resolve.bind(null, 'Hello world'), 500));
-    }
+  wss.on("connection", function connection(ws, req) {
+    console.log("ws: init ws remote port", ws._socket.remotePort);
+    const ip = req ? req.socket.remoteAddress : "127.0.0.1";
+    const headers = req.headers;
+    const userAgent = headers["user-agent"];
+    websocketTable[req.socket.connectionId] = ws;
 
-    const server = credentials ?  https.createServer(credentials) : http.createServer();
+    ws.on("close", function close() {
+      console.log("Closing ws");
+      delete websocketTable[req.socket.connectionId];
+    });
 
-    const wss = new WebSocket.Server({ noServer: true });
-
-    wss.on('connection', function connection(ws, req) {
-
-        const ip = req ? req.socket.remoteAddress: "127.0.0.1";
-        const headers = req.headers;
-        const userAgent = headers["user-agent"];
-        /*
-            When the server runs behind a proxy like NGINX, the de-facto standard is to use the X-Forwarded-For header.
-        */
-       //const ip = req.headers['x-forwarded-for'].split(/\s*,\s*/)[0];
-
-
-        var mockGateway =  {
-            postToConnection: function(params) {
-                this._promise = new Promise(function(resolve,reject) { 
-                    /* params looks like:
-                        {
-                            ConnectionId: event.requestContext.connectionId,
-                            Data: self._serializer.serializeObject(readOperationCompleted)
-                        }
-                    */
-                var serializedHandledOperation = params.Data;
-                ws.send(serializedHandledOperation);
-                resolve(true);
-    
-                });
-                return this;
-            },
-            promise: function() {
-                return this._promise;
-            }
-        };
-
-        //Overrides with our dev equivalent
-        ws.apiGateway = mockGateway;
-        worker.apiGateway = ws.apiGateway;
-        
-        var mockContext = {},
-        mockCallback = function(){};
-
-        //Needs to inject stage property for phront service to use the right info
-        functionModule.connect( {
-                requestContext: {
-                    connectionId: req.socket.connectionId,
-                    stage: program.stage,
-                    identity: {
-                        sourceIp: ip,
-                        userAgent: userAgent
-                    },
-                    authorizer: {
-                        principalId: req.socket.principalId
-                    }
-                },
-                "headers": headers,
-                "body":""
-            },
-            mockContext,
-            mockCallback
-        );    
-
-
-    
-        ws.on('message', function incoming(message) {
-            var mockDefaultContext = {},
-                mockDefaultCallback = function(error, result){},
-                callbackCalled = false;
-
-            
-            worker.apiGateway = ws.apiGateway;
-
-            var defaultPromise = functionModule.default( {
-                    requestContext: {
-                        connectionId: req.socket.connectionId,
-                        stage: program.stage,
-                        identity: {
-                            sourceIp: ip,
-                            userAgent: userAgent
-                        },
-                        authorizer: {
-                            principalId: req.socket.principalId
-                        }
-                    },
-                    "headers": headers,
-                    "body":message
-                },
-                mockDefaultContext,
-                mockDefaultCallback
-            );    
-          
-            if(defaultPromise) {
-                defaultPromise.then((resolvedValue) => {
-                    if(!callbackCalled) {
-                        mockDefaultCallback(null, resolvedValue);
-                    }
-                    
-                }, (error) => {
-                    if(!callbackCalled) {
-                        mockDefaultCallback(error);
-                    }
-                })
-            }
-
-                //console.log('received: %s', message);
-        });
-     
-        //ws.send('something');
+    ws.on("error", function ws_error() {
+      console.log("Error in  ws");
+      delete websocketTable[req.socket.connectionId];
     });
 
     /*
+            When the server runs behind a proxy like NGINX, the de-facto standard is to use the X-Forwarded-For header.
+        */
+    //const ip = req.headers['x-forwarded-for'].split(/\s*,\s*/)[0];
+
+    console.log("ws: mockGateway", mockGateway);
+
+    //Overrides with our dev equivalent
+    ws.apiGateway = mockGateway;
+    worker.apiGateway = mockGateway;
+
+    var mockContext = {},
+      mockCallback = function () {};
+
+    //Needs to inject stage property for phront service to use the right info
+    functionModule.connect(
+      {
+        requestContext: {
+          connectionId: req.socket.connectionId,
+          stage: program.stage,
+          identity: {
+            sourceIp: ip,
+            userAgent: userAgent,
+          },
+          authorizer: {
+            principalId: req.socket.principalId,
+          },
+        },
+        headers: headers,
+        body: "",
+      },
+      mockContext,
+      mockCallback,
+    );
+
+    ws.on("message", function incoming(message) {
+      var mockDefaultContext = {},
+        mockDefaultCallback = function (error, result) {},
+        callbackCalled = false;
+
+      worker.apiGateway = ws.apiGateway;
+
+      var defaultPromise = functionModule.default(
+        {
+          requestContext: {
+            connectionId: req.socket.connectionId,
+            stage: program.stage,
+            identity: {
+              sourceIp: ip,
+              userAgent: userAgent,
+            },
+            authorizer: {
+              principalId: req.socket.principalId,
+            },
+          },
+          headers: headers,
+          body: message,
+        },
+        mockDefaultContext,
+        mockDefaultCallback,
+      );
+
+      if (defaultPromise) {
+        defaultPromise.then(
+          (resolvedValue) => {
+            if (!callbackCalled) {
+              mockDefaultCallback(null, resolvedValue);
+            }
+          },
+          (error) => {
+            if (!callbackCalled) {
+              mockDefaultCallback(error);
+            }
+          },
+        );
+      }
+
+      //console.log('received: %s', message);
+    });
+
+    //ws.send('something');
+  });
+
+  /*
         inspired by https://github.com/websockets/ws/issues/377
     */
 
-    server.on('upgrade', async (request, socket, head) => {
-        let data;
-      
-        try {
-            if(gatewayTimeout) {
-                data = await PromiseTimeout(authorizeAsync(request, socket, head), gatewayTimeout);
-            } else {
-                data = await authorizeAsync(request, socket, head);
-            }
-        } catch (error) {
-            console.log("on upgrade error: ", error);
-            socket.write(`HTTP/1.1 500 ${http.STATUS_CODES[500]}\r\n\r\n`);
-            socket.destroy();
-            return;
-        }
-      
-        wss.handleUpgrade(request, socket, head, (ws) => {
-            wss.emit('connection', ws, request, data);
-        });
-      });
-      
+  server.on("upgrade", async (request, socket, head) => {
+    let data;
 
-    server.on("request", (request, response) => {
-        // handle requests
+    try {
+      if (gatewayTimeout) {
+        data = await PromiseTimeout(
+          authorizeAsync(request, socket, head),
+          gatewayTimeout,
+        );
+      } else {
+        data = await authorizeAsync(request, socket, head);
+      }
+    } catch (error) {
+      console.log("on upgrade error: ", error);
+      socket.write(`HTTP/1.1 500 ${http.STATUS_CODES[500]}\r\n\r\n`);
+      socket.destroy();
+      return;
+    }
 
-        let data = []
-        request
-          .on("data", d => {
-            data.push(d)
-          })
-          .on("end", () => {
-            data = Buffer.concat(data).toString();
-
-
-            var mockDefaultContext = {},
-            mockDefaultCallback = function(){};
-            
-            worker.apiGateway = ws.apiGateway;
-
-            functionModule.default( {
-                    requestContext: {
-                        connectionId: req.socket.connectionId,
-                        stage: program.stage,
-                        identity: {
-                            sourceIp: ip,
-                            userAgent: userAgent
-                        },
-                        authorizer: {
-                            principalId: req.socket.principalId
-                        }
-                    },
-                    "headers": headers,
-                    "body":message
-                },
-                mockDefaultContext,
-                mockDefaultCallback
-            );    
-
-
-
-            response.statusCode = 201;
-            response.end();
-          })
-      
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      wss.emit("connection", ws, request, data);
     });
-      
-    server.listen(port);
+  });
 
+  server.on("request", (request, response) => {
+    // handle requests
+
+    let data = [];
+    request
+      .on("data", (d) => {
+        data.push(d);
+      })
+      .on("end", () => {
+        data = Buffer.concat(data).toString();
+
+        var mockDefaultContext = {},
+          mockDefaultCallback = function () {};
+
+        worker.apiGateway = ws.apiGateway;
+
+        functionModule.default(
+          {
+            requestContext: {
+              connectionId: req.socket.connectionId,
+              stage: program.stage,
+              identity: {
+                sourceIp: ip,
+                userAgent: userAgent,
+              },
+              authorizer: {
+                principalId: req.socket.principalId,
+              },
+            },
+            headers: headers,
+            body: message,
+          },
+          mockDefaultContext,
+          mockDefaultCallback,
+        );
+
+        response.statusCode = 201;
+        response.end();
+      });
+  });
+
+  server.listen(port);
 });
-

--- a/index.js
+++ b/index.js
@@ -212,13 +212,15 @@ workerPromise.then(function (worker) {
 
     const mockGateway =  {
         postToConnection: function(params) {
+            /* params looks like:
+                {
+                    ConnectionId: event.requestContext.connectionId,
+                    Data: self._serializer.serializeObject(readOperationCompleted)
+                }
+            */
+          
             this._promise = new Promise(function(resolve,reject) { 
-                /* params looks like:
-                    {
-                        ConnectionId: event.requestContext.connectionId,
-                        Data: self._serializer.serializeObject(readOperationCompleted)
-                    }
-                */
+            //Retrieve the appropriate websocket on which to respond from our websocket map
             var connectionId = params.ConnectionId;
             var response_ws = websocketTable[connectionId];
             var serializedHandledOperation = params.Data;

--- a/index.js
+++ b/index.js
@@ -242,13 +242,13 @@ workerPromise.then(function (worker) {
         const userAgent = headers["user-agent"];
         websocketTable[req.socket.connectionId] = ws;
 
-        ws.on('close', function close() {
-            console.log("Closing ws");
+        ws.on('close', function close(code,reason) {
+            console.log("Closing ws with code:",code," and Reason:",reason);
             delete websocketTable[req.socket.connectionId];
         });
 
-        ws.on('error', function ws_error() {
-            console.log("Error in ws");
+        ws.on('error', function ws_error(error) {
+            console.log("Error in ws",error);
             delete websocketTable[req.socket.connectionId];
          });
 

--- a/index.js
+++ b/index.js
@@ -411,4 +411,3 @@ workerPromise.then(function (worker) {
     server.listen(port);
 
 });
-

--- a/index.js
+++ b/index.js
@@ -224,7 +224,7 @@ workerPromise.then(function (worker) {
             var connectionId = params.ConnectionId;
             var response_websocket = websocketTable[connectionId];
             var serializedHandledOperation = params.Data;
-            console.log("Sending response on Websocket Connection with Remote IP:", response_ws._socket.remoteAddress ," Remote Port: ", response_ws._socket.remotePort ,  "ConnectionId:",response_ws._socket.connectionId);
+            console.log("Sending response on Websocket Connection with Remote IP:", response_websocket._socket.remoteAddress ," Remote Port: ", response_websocket._socket.remotePort ,  "ConnectionId:",response_websocket._socket.connectionId);
             response_websocket.send(serializedHandledOperation);
             resolve(true);
 

--- a/index.js
+++ b/index.js
@@ -222,10 +222,10 @@ workerPromise.then(function (worker) {
             this._promise = new Promise(function(resolve,reject) { 
             //Retrieve the appropriate websocket on which to respond from our websocket map
             var connectionId = params.ConnectionId;
-            var response_ws = websocketTable[connectionId];
+            var response_websocket = websocketTable[connectionId];
             var serializedHandledOperation = params.Data;
             console.log("Sending response on Websocket Connection with Remote IP:", response_ws._socket.remoteAddress ," Remote Port: ", response_ws._socket.remotePort ,  "ConnectionId:",response_ws._socket.connectionId);
-            response_ws.send(serializedHandledOperation);
+            response_websocket.send(serializedHandledOperation);
             resolve(true);
 
             });

--- a/index.js
+++ b/index.js
@@ -322,11 +322,7 @@ workerPromise.then(function (worker) {
                     }
                 })
             }
-
-                //console.log('received: %s', message);
         });
-     
-        //ws.send('something');
     });
 
     /*

--- a/index.js
+++ b/index.js
@@ -257,11 +257,6 @@ workerPromise.then(function (worker) {
         */
        //const ip = req.headers['x-forwarded-for'].split(/\s*,\s*/)[0];
 
-
-        
-
-        console.log("ws: mockGateway",mockGateway);
-
         //Overrides with our dev equivalent
         ws.apiGateway = mockGateway;
         worker.apiGateway =  mockGateway;


### PR DESCRIPTION
- Problem Statement
	- When multiple clients connect simultaneously to the Worker, the responses for *all* of the client requests are sent to the last client which connected.
- Impact
	- The GCP Cloud run instance limit has to be set to 1:1, meaning that for every client that connects simultaneously, we need to spin up a new cloud run container instance.
	- Startup Latency: We eat the instance cold start time on (TODO: quantify impact,)
	- Cost: We need to scale up many more instances and pay for more cpu/RAM than we would otherwise need. (In a worst case scenario, this would be multiplied by the # of stations we have in all supported factories.)
- Status
	- Wrote a quick tool to stress test by allowing us to open N simultaneous connections to hammer a websocket server.
	- Root Cause Identified
		- TL;DR: Bad Abstraction. "Mock API Gateway" was really a "Websocket Wrapper."
		- Details:
			- Originally, Mod was built to take advantage of AWS's API Gateway. GCP's API Gateway (APIGEE) does not have full feature parity with AWS API Gateway. This bug arises from the system we had to build to bridge that gap.
			- AWS API Gateway (and its associated API) will automatically take care of routing responses to the appropriate clients, and it was not necessary to do any connection management in the worker. On GCP, we have to run our own a websocket server  on the Worker to accept connections, and then forward those messages into the mod worker internals.
			- The bug: the worker has a "Mock API Gateway", which is a utility that is meant to handle the connection I/O (So that the AWS-based code doesn't have to change). 
			- However, a single "Mock API Gateway" only wraps a single websocket connection. 
			- A "Mock API Gateway" is instantiated for every new incoming connection. 
			- Every time a new "Mock API Gateway" is instantiated, the worker's previous "Mock API Gateway" is replaced with the new one.
			- All of the response handling logic would execute, and eventually come back to Worker.MockAPIGateway.postToConnection(), which means all the responses would use the newest MockAPIGateway.
- Next Steps:
	- Upgrade the "Mock API Gateway" to actually manage multiplexing the connections in the same way that the AWS API Gateway does. 
		- Pros:
			- This allows the underlying mod code to still remain the same between AWS & GCP, and allows us to later rely on further abstracting the "Mock API Gateway" into something that can manage *all* of the worker-client I/O.
		- Cons:
			- There is a low risk that this has been masking other 'single thread' concerns. (since the underlying code appeared to be performing correctly even under this condition.)
			- There may be other bugs lurking when maintaining a map of all currently active websocket connections - this approach is stateful.