### PR TITLE
Handle a websocket disconnection while processing a message

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,8 +224,16 @@ workerPromise.then(function (worker) {
             var connectionId = params.ConnectionId;
             var response_websocket = websocketTable[connectionId];
             var serializedHandledOperation = params.Data;
-            console.log("Sending response on Websocket Connection with Remote IP:", response_websocket._socket.remoteAddress ," Remote Port: ", response_websocket._socket.remotePort ,  "ConnectionId:",response_websocket._socket.connectionId);
-            response_websocket.send(serializedHandledOperation);
+            //Need to check if the websocket has already been cleaned up and removed from the table by now.
+            //This can happen if it's closed while we're processing a request.
+            if (response_websocket) {
+              console.log("Sending response on Websocket Connection with Remote IP:", response_websocket._socket.remoteAddress, " Remote Port: ", response_websocket._socket.remotePort, "ConnectionId:", response_websocket._socket.connectionId);
+              response_websocket.send(serializedHandledOperation);
+            }
+            else {
+              console.log("Would have sent a response to a websocket connection, but the socket was closed before we were ready to send this data.")
+            }
+            //TODO: Should we resolve(false) if we get here and the return connection is closed?
             resolve(true);
 
             });

--- a/index.js
+++ b/index.js
@@ -233,9 +233,7 @@ workerPromise.then(function (worker) {
             else {
               console.log("Would have sent a response to a websocket connection, but the socket was closed before we were ready to send this data.")
             }
-            //TODO: Should we resolve(false) if we get here and the return connection is closed?
             resolve(true);
-
             });
             return this;
         },


### PR DESCRIPTION
Added code to cover a failure case where the websocket is disconnected & cleaned up before we finish processing a message.

1. Should we still call `resolve(true)` in the case where the websocket is disconnected? Or should we call `resolve(false)`? I havent had time to dive deep into that promise chain yet.